### PR TITLE
Patch submission for #14.

### DIFF
--- a/de.devboost.eclipse.junitloop/plugin.xml
+++ b/de.devboost.eclipse.junitloop/plugin.xml
@@ -15,6 +15,12 @@
       </testRunListener>
    </extension>
    <extension
+      id="de.devboost.eclipse.junitloop.testFailure"
+      point="org.eclipse.core.resources.markers"
+      name="Test Failure">
+      <super type="org.eclipse.core.resources.problemmarker"/>
+   </extension>
+   <extension
          point="org.eclipse.ui.viewActions">
       <viewContribution
             id="de.devboost.eclipse.junitloop.viewContribution"


### PR DESCRIPTION
Define a custom problem marker type for test failures.

When a JUnitLoop test session starts, remove all test failure markers
from the workspace.

On each test failure, create a new test failure marker, which appears in
the Problems view and links to the line in the test case where the
failure occurred.
